### PR TITLE
add conditional around module.export

### DIFF
--- a/index.js
+++ b/index.js
@@ -1711,4 +1711,6 @@ function GraphemeSplitter(){
 	return this;
 }
 
-module.exports = GraphemeSplitter
+if (typeof module != 'undefined' && module.exports) {
+    module.exports = GraphemeSplitter;
+}


### PR DESCRIPTION
When attempting to use this library client side, loaded via CDN an error occurs if no module system is being used.  This small change allows the library to work with and without a module system.

Closes #16 