### PR TITLE
Add iterateGraphemes method

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ var splitter = new GraphemeSplitter();
 // split the string to an array of grapheme clusters (one string each)
 var graphemes = splitter.splitGraphemes(string);
 
+// iterate the string to an iterable iterator of grapheme clusters (one string each)
+var graphemes = splitter.iterateGraphemes(string);
+
 // or do this if you just need their number
 var graphemeCount = splitter.countGraphemes(string);
 ```

--- a/index.d.ts
+++ b/index.d.ts
@@ -17,6 +17,8 @@ declare class GraphemeSplitter {
   countGraphemes(s: string): number
   /** split the string to an array of grapheme clusters */
   splitGraphemes(s: string): string[]
+  /** iterate the string to an iterable iterator of grapheme clusters */
+  iterateGraphemes(s: string): IterableIterator<string>
 }
 
 export = GraphemeSplitter

--- a/index.js
+++ b/index.js
@@ -220,7 +220,34 @@ function GraphemeSplitter(){
 		}
 		return res;
 	};
-	
+
+	// Returns the iterator of grapheme clusters there are in the given string
+	this.iterateGraphemes = function(str) {
+		var index = 0;
+		var res = {
+			next: (function() {
+				var value;
+				var brk;
+				if ((brk = this.nextBreak(str, index)) < str.length) {
+					value = str.slice(index, brk);
+					index = brk;
+					return { value: value, done: false };
+				}
+				if (index < str.length) {
+					value = str.slice(index);
+					index = str.length;
+					return { value: value, done: false };
+				}
+				return { value: undefined, done: true };
+			}).bind(this)
+		};
+		// ES2015 @@iterator method (iterable) for spread syntax and for...of statement
+		if (typeof Symbol !== 'undefined' && Symbol.iterator) {
+			res[Symbol.iterator] = function() {return res};
+		}
+		return res;
+	};
+
 	// Returns the number of grapheme clusters there are in the given string
 	this.countGraphemes = function(str){
 		var count = 0;

--- a/tests/grapheme_splitter_tests.js
+++ b/tests/grapheme_splitter_tests.js
@@ -54,6 +54,20 @@ test('splitGraphemes returns properly split list from string', t => {
   t.end();
 });
 
+test('iterateGraphemes returns properly split iterator from string', t => {
+  const splitter = new GraphemeSplitter();
+
+  t.plan(testData.length);
+
+  testData.forEach( ({ input, expected }) => {
+    const result = splitter.iterateGraphemes(input);
+
+    t.deepLooseEqual([...result], expected);
+  });
+
+  t.end();
+});
+
 test('countGraphemes returns the correct number of graphemes in string', t => {
   const splitter = new GraphemeSplitter();
 


### PR DESCRIPTION
The `splitGraphemes` method blocks main thread when applied huge length string.
To solve this, I create the `iterateGraphemes` method based on the Iterator interface of ES2015.

e.g. get 30 graphemes of string
```javascript
// ES2015
const graphemes = [];

let i = 0;
for (const grapheme of graphemeSplitter.iterateGraphemes(hugeStr)) {
  graphemes.push(grapheme);
  ++i;
  if (i === 30) { break; }
}
```

```javascript
// ES5.1
var graphemes = [];

var iterator = graphemeSplitter.iterateGraphemes(hugeStr);
var result, i;
for (i = 0; i < 30; ++i) {
  result = iterator.next();
  if (result.done) { break; }
  graphemes.push(result.value);
}
```