### PR TITLE
fix: Remove engines

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,8 +30,5 @@
   "dependencies": {},
   "devDependencies": {
     "tape": "^4.6.3"
-  },
-  "engines": {
-    "npm": "~7.3.0"
   }
 }


### PR DESCRIPTION
## What?
This removed wrongly specified npm version under `engines` in `package.json`.

Fixes https://github.com/orling/grapheme-splitter/issues/19